### PR TITLE
Remove unused travis test scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ node_js:
   - 0.10
 
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm install --dev --silent
-  - npm install --silent karma-firefox-launcher karma-phantomjs-launcher
 
 script: gulp


### PR DESCRIPTION
I noticed in my last pull request that travis took a while. 

`.travis.yml` was installing karma-firefox-launcher and karma-phantomjs-launcher, which is wasteful because there are not tests defined in the gulp file.
