### PR TITLE
updated example3 of tabs with correct format and correct name

### DIFF
--- a/src/tab/examples.html
+++ b/src/tab/examples.html
@@ -90,7 +90,7 @@
         </div>
 
         <div data-copy-to="#example3">
-          <sm-tab-menu tabs="{first3:'First', second3:'Second', third3:'Third'}" active="model3" class="pointing secondary"></sm-tab-menu>
+          <sm-tab-menu tabs="{first3:'First', second3:'Second', third3:'Third'}" active="'third3'" class="pointing secondary"></sm-tab-menu>
           <sm-tab name="first3">
             <img class="ui wireframe image" src="http://semantic-ui.com/images/wireframe/paragraph.png">
           </sm-tab>


### PR DESCRIPTION
following example3 will not set active class on 3rd tab, so changing the format with right tab name
