### PR TITLE
Fixed getDefaultText + value/label binding related exception

### DIFF
--- a/src/dropdown/sm-dropdown.js
+++ b/src/dropdown/sm-dropdown.js
@@ -136,7 +136,7 @@
     $scope.getDefaultText = function()
     {
       var defaultText = $scope.defaultText ? $scope.defaultText : '';
-      return ( $scope.isEmpty() ? defaultText : $scope.findMatchingItem($scope.model) );
+      return ( $scope.isEmpty() ? defaultText : $scope.translateValue($scope.findMatchingItem($scope.model)) );
     };
 
     // Finds an item instance that has the exact same value as the given value.


### PR DESCRIPTION
getDefaultText throws an exception every time dropdown value is updated when label/value bindings are present because it passes an object into the html sanitizer instead of a translated value.