### PR TITLE
Allowing `undefined` value to clear dropdown.

### DIFF
--- a/src/dropdown/sm-dropdown.js
+++ b/src/dropdown/sm-dropdown.js
@@ -162,7 +162,7 @@
     return function (scope, element, attributes) {
       var applyValue = function (value) {
         $timeout(function () {
-          if (value === null) {
+          if (value == null) {
             element.dropdown('clear');
           } else if(value === false){
             // Do nothing


### PR DESCRIPTION
When setting the value of the dropdown to `undefined`, it should reset as well, not only when it's `null`.